### PR TITLE
Fix redis-check-aof incorrectly considering data in manifest format a…

### DIFF
--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -495,7 +495,7 @@ tags {"aof external:skip"} {
 
     test {Test valkey-check-aof for old style rdb-preamble AOF} {
         catch {
-            exec src/valkey-check-aof tests/assets/rdb-preamble.aof
+	    exec src/valkey-check-aof tests/assets/rdb-preamble.aof
         } result
         assert_match "*Start checking Old-Style AOF*RDB preamble is OK, proceeding with AOF tail*is valid*" $result
     }

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1241,9 +1241,9 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         assert_equal {} [$rd read]
         set end [clock milliseconds]
 
-        # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
-        # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
-        assert_range [expr $end-$start] 1000 1150
+        # In the past, this time would have been 1000+200, in order to avoid
+        # timing issues, we increase the range a bit.
+        assert_range [expr $end-$start] 1000 1100
 
         r debug set-active-expire 1
         $rd close

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -518,9 +518,9 @@ start_server {
         assert_equal {} [$rd2 read]
         set end [clock milliseconds]
 
-        # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
-        # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
-        assert_range [expr $end-$start] 1000 1150
+        # In the past, this time would have been 1000+200, in order to avoid
+        # timing issues, we increase the range a bit.
+        assert_range [expr $end-$start] 1000 1100
 
         $rd1 close
         $rd2 close

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2009,9 +2009,9 @@ start_server {tags {"zset"}} {
             assert_equal {} [$rd read]
             set end [clock milliseconds]
 
-            # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
-            # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
-            assert_range [expr $end-$start] 1000 1150
+            # In the past, this time would have been 1000+200, in order to avoid
+            # timing issues, we increase the range a bit.
+            assert_range [expr $end-$start] 1000 1100
 
             r debug set-active-expire 1
             $rd close


### PR DESCRIPTION
…s MP-AOF (#12958)

The check in fileIsManifest misjudged the manifest file. For example, if resp aof contains "file", it will be considered a manifest file and the check will fail:
```
*3
$3
set
$4
file
$4
file
```

In #12951, if the preamble aof also contains it, it will also fail. Fixes #12951.

the bug was happening if the the word "file" is mentioned in the first 1024 lines of the AOF. and now as soon as it finds a non-comment line it'll break (if it contains "file" or doesn't)

(cherry picked from commit da727ad445a640950baa097124070468a0316cc9)