### PR TITLE
Key Memory Stats

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1680,6 +1680,9 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->repl_offset = 0;
     listSetFreeMethod(node->fail_reports, zfree);
     node->is_node_healthy = 0;
+    for (int j = 0; j < CLUSTER_SLOTS; j++) {
+        node->memory_usage[j] = 0;
+    }
     return node;
 }
 

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -373,6 +373,7 @@ struct _clusterNode {
     list *fail_reports;                     /* List of nodes signaling this as failing */
     int is_node_healthy;                    /* Boolean indicating the cached node health.
                                                Update with updateAndCountChangedNodeHealth(). */
+    unsigned long long memory_usage[CLUSTER_SLOTS];
 };
 
 /* Struct used for storing slot statistics. */

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -9,6 +9,7 @@
 
 typedef enum {
     KEY_COUNT,
+    SLOT_MEMORY_USAGE,
     CPU_USEC,
     NETWORK_BYTES_IN,
     NETWORK_BYTES_OUT,
@@ -51,6 +52,7 @@ static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     case CPU_USEC: slot_stat = server.cluster->slot_stats[slot].cpu_usec; break;
     case NETWORK_BYTES_IN: slot_stat = server.cluster->slot_stats[slot].network_bytes_in; break;
     case NETWORK_BYTES_OUT: slot_stat = server.cluster->slot_stats[slot].network_bytes_out; break;
+    case SLOT_MEMORY_USAGE:
     case SLOT_STAT_COUNT:
     case INVALID: serverPanic("Invalid slot stat type %d was found.", stat_type);
     }
@@ -95,9 +97,12 @@ static void addReplySlotStat(client *c, int slot) {
                              * and 1st index represents (map) usage statistics. */
     addReplyLongLong(c, slot);
     addReplyMapLen(c, (server.cluster_slot_stats_enabled) ? SLOT_STAT_COUNT
-                                                          : 1); /* Nested map representing slot usage statistics. */
+                                                          : 2); /* Nested map representing slot usage statistics. */
     addReplyBulkCString(c, "key-count");
     addReplyLongLong(c, countKeysInSlot(slot));
+
+    addReplyBulkCString(c, "memory-usage");
+    addReplyLongLong(c, server.cluster->myself->memory_usage[slot]);
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */

--- a/src/db.c
+++ b/src/db.c
@@ -770,6 +770,16 @@ void flushAllDataAndResetRDB(int flags) {
         rsiptr = rdbPopulateSaveInfo(&rsi);
         rdbSave(REPLICA_REQ_NONE, server.rdb_filename, rsiptr, RDBFLAGS_NONE);
     }
+    server.strings_count = 0;
+    server.strings_memory = 0;
+    server.lists_count = 0;
+    server.lists_memory = 0;
+    server.hashes_count = 0;
+    server.hashes_count = 0;
+    server.sets_count = 0;
+    server.sets_memory = 0;
+    server.zsets_memory = 0;
+    server.zsets_memory = 0;
 
 #if defined(USE_JEMALLOC)
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.

--- a/src/server.c
+++ b/src/server.c
@@ -2939,6 +2939,16 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_replicas_count = 0;
     server.last_sig_received = 0;
+    server.strings_count = 0;
+    server.strings_memory = 0;
+    server.lists_count = 0;
+    server.lists_memory = 0;
+    server.hashes_count = 0;
+    server.hashes_memory = 0;
+    server.sets_count = 0;
+    server.sets_count = 0;
+    server.zsets_memory = 0;
+    server.zsets_memory = 0;
 
     /* Initiate acl info struct */
     server.acl_info.invalid_cmd_accesses = 0;
@@ -5666,6 +5676,7 @@ dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, i
         "errorstats",
         "cluster",
         "keyspace",
+        "keystats",
         NULL,
     };
     if (!defaults) defaults = default_sections;
@@ -6323,6 +6334,23 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         }
     }
 
+    /* Key stats */
+    if (all_sections || (dictFind(section_dict, "keystats") != NULL)) {
+        if (sections++) info = sdscat(info, "\r\n");
+        info = sdscatprintf(info, "# Keystats\r\n");
+        info = sdscatprintf(info, "string_count:%lld\r\n", server.strings_count);
+        info = sdscatprintf(info, "string_tot_memory:%lld\r\n", server.strings_memory);
+        info = sdscatprintf(info, "list_count:%lld\r\n", server.lists_count);
+        info = sdscatprintf(info, "list_tot_memory:%lld\r\n", server.lists_memory);
+        info = sdscatprintf(info, "hash_count:%lld\r\n", server.hashes_count);
+        info = sdscatprintf(info, "hash_tot_memory:%lld\r\n", server.hashes_memory);
+        info = sdscatprintf(info, "set_count:%lld\r\n", server.sets_count);
+        info = sdscatprintf(info, "set_tot_memory:%lld\r\n", server.sets_memory);
+        info = sdscatprintf(info, "zset_count:%lld\r\n", server.zsets_count);
+        info = sdscatprintf(info, "zset_tot_memory:%lld\r\n", server.zsets_memory);
+    }
+
+
     /* Get info from modules.
      * Returned when the user asked for "everything", "modules", or a specific module section.
      * We're not aware of the module section names here, and we rather avoid the search when we can.
@@ -6860,6 +6888,118 @@ void loadDataFromDisk(void) {
 void serverOutOfMemoryHandler(size_t allocation_size) {
     serverLog(LL_WARNING, "Out Of Memory allocating %zu bytes!", allocation_size);
     serverPanic("Valkey aborting for OUT OF MEMORY. Allocating %zu bytes!", allocation_size);
+}
+
+size_t getKeyMemoryUsage(robj *obj) {
+    size_t asize = 0;
+    if (obj->encoding == OBJ_ENCODING_INT) {
+        asize = sizeof(*obj);
+    } else if (obj->encoding == OBJ_ENCODING_RAW) {
+        asize = sdsAllocSize(obj->ptr) + sizeof(*obj);
+    } else if (obj->encoding == OBJ_ENCODING_EMBSTR) {
+        asize = zmalloc_size((void *)obj);
+    }
+    return asize;
+}
+
+size_t getStringValueMemoryUsage(robj *obj) {
+    size_t asize = 0;
+    if (obj->encoding == OBJ_ENCODING_INT) {
+        asize = sizeof(*obj);
+    } else if (obj->encoding == OBJ_ENCODING_RAW) {
+        asize = sdsAllocSize(obj->ptr) + sizeof(*obj);
+    } else if (obj->encoding == OBJ_ENCODING_EMBSTR) {
+        asize = zmalloc_size((void *)obj);
+    }
+    return asize;
+}
+
+size_t getListValueMemoryUsage(robj *obj) {
+    size_t asize = 0, elesize = 0;
+    if (obj->encoding == OBJ_ENCODING_QUICKLIST) {
+        quicklist *ql = obj->ptr;
+        quicklistNode *node = ql->head;
+        asize = sizeof(*obj) + sizeof(quicklist);
+        elesize += sizeof(quicklistNode) + zmalloc_size(node->entry);
+        node = node->next;
+        while (node) {
+            elesize += sizeof(quicklistNode) + zmalloc_size(node->entry);
+            node = node->next;
+        }
+        asize += elesize;
+    } else {
+        asize = sizeof(*obj) + zmalloc_size(obj->ptr);
+    }
+    return asize;
+}
+
+size_t getHashValueMemoryUsage(robj *obj) {
+    size_t asize = 0, elesize = 0, samples = 0;
+
+    if (obj->encoding == OBJ_ENCODING_LISTPACK) {
+        asize = sizeof(*obj) + zmalloc_size(obj->ptr);
+    } else if (obj->encoding == OBJ_ENCODING_HASHTABLE) {
+        hashtable *ht = obj->ptr;
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, ht, 0);
+        void *next;
+
+        asize = sizeof(*obj) + hashtableMemUsage(ht);
+        while (hashtableNext(&iter, &next)) {
+            elesize += hashTypeEntryMemUsage(next);
+            samples++;
+        }
+        hashtableResetIterator(&iter);
+        if (samples) asize += (double)elesize / samples * hashtableSize(ht);
+    }
+    return asize;
+}
+
+size_t getSetValueMemoryUsage(robj *obj) {
+    size_t asize = 0, elesize = 0, samples = 0;
+
+    if (obj->encoding == OBJ_ENCODING_HASHTABLE) {
+        hashtable *ht = obj->ptr;
+        asize = sizeof(*obj) + hashtableMemUsage(ht);
+
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, ht, 0);
+        void *next;
+        while (hashtableNext(&iter, &next)) {
+            sds element = next;
+            elesize += sdsAllocSize(element);
+            samples++;
+        }
+        hashtableResetIterator(&iter);
+        if (samples) asize += (double)elesize / samples * hashtableSize(ht);
+    } else if (obj->encoding == OBJ_ENCODING_INTSET) {
+        asize = sizeof(*obj) + zmalloc_size(obj->ptr);
+    } else if (obj->encoding == OBJ_ENCODING_LISTPACK) {
+        asize = sizeof(*obj) + zmalloc_size(obj->ptr);
+    }
+    return asize;
+}
+
+size_t getZsetValueMemoryUsage(robj *obj) {
+    size_t asize = 0, elesize = 0, samples = 0;
+
+    if (obj->encoding == OBJ_ENCODING_LISTPACK) {
+        asize = sizeof(*obj) + zmalloc_size(obj->ptr);
+    } else if (obj->encoding == OBJ_ENCODING_SKIPLIST) {
+        hashtable *ht = ((zset *)obj->ptr)->ht;
+        zskiplist *zsl = ((zset *)obj->ptr)->zsl;
+        zskiplistNode *znode = zsl->header->level[0].forward;
+        asize = sizeof(*obj) + sizeof(zset) + sizeof(zskiplist) +
+                hashtableMemUsage(ht) + zmalloc_size(zsl->header);
+        while (znode != NULL) {
+            elesize += sdsAllocSize(znode->ele);
+            elesize += zmalloc_size(znode);
+            samples++;
+            znode = znode->level[0].forward;
+        }
+        if (samples) asize += (double)elesize / samples * hashtableSize(ht);
+    }
+    return asize;
 }
 
 /* Callback for sdstemplate on proc-title-template. See valkey.conf for

--- a/src/server.h
+++ b/src/server.h
@@ -2196,6 +2196,16 @@ struct valkeyServer {
     /* Local environment */
     char *locale_collate;
     char *debug_context; /* A free-form string that has no impact on server except being included in a crash report. */
+    unsigned long long lists_count;
+    unsigned long long lists_memory;
+    unsigned long long strings_count;
+    unsigned long long strings_memory;
+    unsigned long long hashes_count;
+    unsigned long long hashes_memory;
+    unsigned long long sets_count;
+    unsigned long long sets_memory;
+    unsigned long long zsets_count;
+    unsigned long long zsets_memory;
 };
 
 #define MAX_KEYS_BUFFER 256
@@ -3275,6 +3285,12 @@ void *activeDefragAlloc(void *ptr);
 robj *activeDefragStringOb(robj *ob);
 void dismissSds(sds s);
 void dismissMemoryInChild(void);
+size_t getKeyMemoryUsage(robj *obj);
+size_t getStringValueMemoryUsage(robj *obj);
+size_t getListValueMemoryUsage(robj *obj);
+size_t getHashValueMemoryUsage(robj *obj);
+size_t getSetValueMemoryUsage(robj *obj);
+size_t getZsetValueMemoryUsage(robj *obj);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1 << 0)     /* Do proper shutdown. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -814,12 +814,12 @@ void hsetnxCommand(client *c) {
 void hsetCommand(client *c) {
     int i, created = 0;
     robj *o;
-    /*
+
     int slot_number = 0;
     unsigned long long update_key_memory_usage = 0;
     size_t previous_value_memory_usage = 0;
     size_t new_value_memory_usage = 0;
-    */
+
 
     if ((c->argc % 2) == 1) {
         addReplyErrorArity(c);
@@ -827,7 +827,7 @@ void hsetCommand(client *c) {
     }
 
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return; // Add for compile
-    /*
+
     o = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, o, OBJ_HASH)) return;
     if (o == NULL) {
@@ -838,7 +838,7 @@ void hsetCommand(client *c) {
     } else {
         previous_value_memory_usage = getHashValueMemoryUsage(o);
     }
-    */
+
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
 
     for (i = 2; i < c->argc; i += 2) created += !hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, HASH_SET_COPY);
@@ -846,14 +846,14 @@ void hsetCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
     server.dirty += (c->argc - 2) / 2;
-    /*
+
     new_value_memory_usage = getHashValueMemoryUsage(o);
     server.hashes_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
     if (server.cluster_enabled) {
         slot_number = getKeySlot(c->argv[1]->ptr);
         server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
     }
-    */
+
 
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -33,6 +33,8 @@
  */
 
 #include "server.h"
+#include "cluster.h"
+#include "cluster_legacy.h"
 #include <math.h>
 #include <stdbool.h>
 
@@ -812,13 +814,31 @@ void hsetnxCommand(client *c) {
 void hsetCommand(client *c) {
     int i, created = 0;
     robj *o;
+    /*
+    int slot_number = 0;
+    unsigned long long update_key_memory_usage = 0;
+    size_t previous_value_memory_usage = 0;
+    size_t new_value_memory_usage = 0;
+    */
 
     if ((c->argc % 2) == 1) {
         addReplyErrorArity(c);
         return;
     }
 
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return; // Add for compile
+    /*
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        server.hashes_count++;
+        update_key_memory_usage = getKeyMemoryUsage(c->argv[1]);
+    } else {
+        previous_value_memory_usage = getHashValueMemoryUsage(o);
+    }
+    */
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
 
     for (i = 2; i < c->argc; i += 2) created += !hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, HASH_SET_COPY);
@@ -826,6 +846,14 @@ void hsetCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
     server.dirty += (c->argc - 2) / 2;
+    /*
+    new_value_memory_usage = getHashValueMemoryUsage(o);
+    server.hashes_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    if (server.cluster_enabled) {
+        slot_number = getKeySlot(c->argv[1]->ptr);
+        server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    }
+    */
 
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -28,6 +28,8 @@
  */
 
 #include "server.h"
+#include "cluster.h"
+#include "cluster_legacy.h"
 
 /*-----------------------------------------------------------------------------
  * List API
@@ -461,6 +463,13 @@ void listTypeDelRange(robj *subject, long start, long count) {
  * 'xx': push if key exists. */
 void pushGenericCommand(client *c, int where, int xx) {
     int j;
+    /*
+    int found = 1;
+    int slot_number = 0;
+    unsigned long long update_key_memory_usage = 0;
+    size_t previous_value_memory_usage = 0;
+    size_t new_value_memory_usage = 0;
+    */
 
     robj *lobj = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, lobj, OBJ_LIST)) return;
@@ -469,10 +478,19 @@ void pushGenericCommand(client *c, int where, int xx) {
             addReply(c, shared.czero);
             return;
         }
-
         lobj = createListListpackObject();
         dbAdd(c->db, c->argv[1], &lobj);
+        // found = 0;
     }
+
+    /*
+    if (found) {
+        previous_value_memory_usage = getListValueMemoryUsage(lobj);
+    } else {
+        server.lists_count++;
+        update_key_memory_usage = getKeyMemoryUsage(c->argv[1]);
+    }
+    */
 
     listTypeTryConversionAppend(lobj, c->argv, 2, c->argc - 1, NULL, NULL);
     for (j = 2; j < c->argc; j++) {
@@ -480,6 +498,14 @@ void pushGenericCommand(client *c, int where, int xx) {
         server.dirty++;
     }
 
+    /*
+    new_value_memory_usage = getListValueMemoryUsage(lobj);
+    server.lists_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    if (server.cluster_enabled) {
+        slot_number = getKeySlot(c->argv[1]->ptr);
+        server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    }
+    */
     signalModifiedKey(c, c->db, c->argv[1]);
     char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     notifyKeyspaceEvent(NOTIFY_LIST, event, c->argv[1], c->db->id);
@@ -533,6 +559,7 @@ void linsertCommand(client *c) {
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
     listTypeTryConversionAppend(subject, c->argv, 4, 4, NULL, NULL);
+    // size_t previous_memory = getListValueMemoryUsage(subject);
 
     /* Seek pivot from head to tail */
     iter = listTypeInitIterator(subject, 0, LIST_TAIL);
@@ -549,6 +576,7 @@ void linsertCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST, "linsert", c->argv[1], c->db->id);
         server.dirty++;
+        // server.lists_memory += getListValueMemoryUsage(subject) - previous_memory;
     } else {
         /* Notify client of a failed insert */
         addReplyLongLong(c, -1);
@@ -603,11 +631,13 @@ void lsetCommand(client *c) {
     if ((getLongFromObjectOrReply(c, c->argv[2], &index, NULL) != C_OK)) return;
 
     listTypeTryConversionAppend(o, c->argv, 3, 3, NULL, NULL);
+    // size_t previous_memory = getListValueMemoryUsage(o);
     if (listTypeReplaceAtIndex(o, index, value)) {
         /* We might replace a big item with a small one or vice versa, but we've
          * already handled the growing case in listTypeTryConversionAppend()
          * above, so here we just need to try the conversion for shrinking. */
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
+        // server.lists_memory = server.lists_memory - previous_memory + getListValueMemoryUsage(o);
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST, "lset", c->argv[1], c->db->id);
         server.dirty++;
@@ -890,6 +920,8 @@ void ltrimCommand(client *c) {
         ltrim = start;
         rtrim = llen - end - 1;
     }
+    // size_t previous_memory = getListValueMemoryUsage(o);
+    // size_t key_memory = getKeyMemoryUsage(c->argv[1]);
 
     /* Remove list elements to perform the trim */
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
@@ -906,8 +938,11 @@ void ltrimCommand(client *c) {
     if (listTypeLength(o) == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        // server.lists_memory = server.lists_memory - previous_memory - key_memory;
+        // server.lists_count--;
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
+        // server.lists_memory += previous_memory - getListValueMemoryUsage(o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
     server.dirty += (ltrim + rtrim);
@@ -1041,6 +1076,8 @@ void lremCommand(client *c) {
         li = listTypeInitIterator(subject, 0, LIST_TAIL);
     }
 
+    // size_t previous_memory = getListValueMemoryUsage(subject);
+    // size_t key_memory = getKeyMemoryUsage(c->argv[1]);
     listTypeEntry entry;
     while (listTypeNext(li, &entry)) {
         if (listTypeEqual(&entry, obj)) {
@@ -1057,8 +1094,11 @@ void lremCommand(client *c) {
         if (listTypeLength(subject) == 0) {
             dbDelete(c->db, c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+            // server.lists_memory = server.lists_memory - previous_memory - key_memory;
+            // server.lists_count--;
         } else {
             listTypeTryConversion(subject, LIST_CONV_SHRINKING, NULL, NULL);
+            // server.lists_memory -= previous_memory - getListValueMemoryUsage(subject);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
     }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -35,6 +35,8 @@
 #include "server.h"
 #include "hashtable.h"
 #include "intset.h" /* Compact integer set structure */
+#include "cluster.h"
+#include "cluster_legacy.h"
 
 /*-----------------------------------------------------------------------------
  * Set Commands
@@ -597,6 +599,12 @@ robj *setTypeDup(robj *o) {
 void saddCommand(client *c) {
     robj *set;
     int j, added = 0;
+    /*
+    int slot_number = 0;
+    unsigned long long update_key_memory_usage = 0;
+    size_t previous_value_memory_usage = 0;
+    size_t new_value_memory_usage = 0;
+    */
 
     set = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, set, OBJ_SET)) return;
@@ -604,8 +612,11 @@ void saddCommand(client *c) {
     if (set == NULL) {
         set = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         dbAdd(c->db, c->argv[1], &set);
+        // server.sets_count++;
+        // update_key_memory_usage = getKeyMemoryUsage(c->argv[1]);
     } else {
         setTypeMaybeConvert(set, c->argc - 2);
+        // previous_value_memory_usage = getSetValueMemoryUsage(set);
     }
 
     for (j = 2; j < c->argc; j++) {
@@ -615,6 +626,14 @@ void saddCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_SET, "sadd", c->argv[1], c->db->id);
         server.dirty += added;
+        /*
+            new_value_memory_usage = getSetValueMemoryUsage(set);
+            server.sets_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+            if (server.cluster_enabled) {
+                slot_number = getKeySlot(c->argv[1]->ptr);
+                server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+            }
+        */
     }
     addReplyLongLong(c, added);
 }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -33,6 +33,8 @@
  */
 
 #include "server.h"
+#include "cluster.h"
+#include "cluster_legacy.h"
 #include <math.h> /* isnan(), isinf() */
 
 /* Forward declarations */
@@ -100,6 +102,12 @@ void setGenericCommand(client *c,
     long long milliseconds = 0; /* initialized to avoid any harmness warning */
     int found = 0;
     int setkey_flags = 0;
+    /*
+    int slot_number = 0;
+    unsigned long long update_key_memory_usage = 0;
+    size_t previous_value_memory_usage = 0;
+    size_t new_value_memory_usage = 0;
+    */
 
     if (expire && getExpireMillisecondsOrReply(c, expire, flags, unit, &milliseconds) != C_OK) {
         return;
@@ -110,6 +118,7 @@ void setGenericCommand(client *c,
         if (getGenericCommand(c) == C_ERR) goto cleanup;
     }
 
+    // slot_number = server.cluster_enabled ? getKeySlot(key->ptr) : 0;
     robj *existing_value = lookupKeyWrite(c->db, key);
     found = existing_value != NULL;
 
@@ -152,8 +161,26 @@ void setGenericCommand(client *c,
      * created again. */
     setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
+    /*
+    if (found) {
+        previous_value_memory_usage = getStringValueMemoryUsage(existing_value);
+    }
+    */
 
     setKey(c, c->db, key, &val, setkey_flags);
+
+    /*
+    if (!found) {
+        server.strings_count++;
+        update_key_memory_usage = getKeyMemoryUsage(key);
+    }
+    new_value_memory_usage = getStringValueMemoryUsage(val);
+    server.strings_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    if (server.cluster_enabled) {
+        server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+    }
+    */
+
     if (expire) val = setExpire(c, c->db, key, milliseconds);
 
     /* By setting the reallocated value back into argv, we can avoid duplicating

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -62,6 +62,8 @@
 
 #include "server.h"
 #include "intset.h" /* Compact integer set structure */
+#include "cluster.h"
+#include "cluster_legacy.h"
 #include <math.h>
 
 #include "valkey_strtod.h"
@@ -1731,6 +1733,12 @@ static void zaddGenericCommand(client *c, int flags) {
     size_t maxelelen = 0;
     int scoreidx = 0;
     int reply_err = 0;
+    /*
+    int slot_number = 0;
+    unsigned long long update_key_memory_usage = 0;
+    size_t previous_value_memory_usage = 0;
+    size_t new_value_memory_usage = 0;
+    */
 
     /* The following vars are used in order to track what the command actually
      * did during the execution, to reply to the client and to trigger the
@@ -1813,8 +1821,11 @@ static void zaddGenericCommand(client *c, int flags) {
         if (xx) goto reply_to_client; /* No key + XX option: nothing to do. */
         zobj = zsetTypeCreate(elements, maxelelen);
         dbAdd(c->db, key, &zobj);
+        // server.zsets_count++;
+        // update_key_memory_usage = getKeyMemoryUsage(c->argv[1]);
     } else {
         zsetTypeMaybeConvert(zobj, elements, maxelelen);
+        // previous_value_memory_usage = getZsetValueMemoryUsage(zobj);
     }
 
     for (j = 0; j < elements; j++) {
@@ -1839,6 +1850,14 @@ static void zaddGenericCommand(client *c, int flags) {
     if (added || updated) {
         signalModifiedKey(c, c->db, key);
         notifyKeyspaceEvent(NOTIFY_ZSET, incr ? "zincr" : "zadd", key, c->db->id);
+        /*
+            new_value_memory_usage = getZsetValueMemoryUsage(zobj);
+            server.zsets_memory += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+            if (server.cluster_enabled) {
+                slot_number = getKeySlot(c->argv[1]->ptr);
+                server.cluster->myself->memory_usage[slot_number] += update_key_memory_usage + new_value_memory_usage - previous_value_memory_usage;
+            }
+        */
     }
 
 reply_to_client:


### PR DESCRIPTION
Test script:  

./src/valkey-benchmark -h 172.25.0.58 -p 7000 -r 1500000 -n 100000 -c 1000 -t 100 -d 100000 lpush key:__rand_int__ member:__rand_int__

Result:

# Keyspace
db0:keys=96763,expires=0,avg_ttl=0

# Keystats
list_count:96763
list_tot_memory:4722296
172.25.0.58:7000> dbsize
(integer) 96763

# Memory
used_memory:9385552
used_memory_human:8.95M
used_memory_rss:16510976
used_memory_rss_human:15.75M
used_memory_peak:18459344
used_memory_peak_human:17.60M
used_memory_peak_perc:50.84%
used_memory_overhead:3740288
used_memory_startup:880216
used_memory_dataset:5645264
used_memory_dataset_perc:66.37%
allocator_allocated:9679008
